### PR TITLE
RH2 Patches Update - April 2024

### DIFF
--- a/Patches/RH2 DOOM/RH2_DOOM_CE_Patch_RangedDOOM_Weapons.xml
+++ b/Patches/RH2 DOOM/RH2_DOOM_CE_Patch_RangedDOOM_Weapons.xml
@@ -13,7 +13,7 @@
 					<defName>RHGun_DOOM_UACEMGPistol</defName>
 					<statBases>
 						<Mass>1.35</Mass>
-						<RangedWeapon_Cooldown>0.05</RangedWeapon_Cooldown>
+						<RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
 						<SightsEfficiency>0.70</SightsEfficiency>
 						<ShotSpread>0.176</ShotSpread>
 						<SwayFactor>1.27</SwayFactor>

--- a/Patches/RH2 Faction - Task Force 141/TaskForce141_Guns.xml
+++ b/Patches/RH2 Faction - Task Force 141/TaskForce141_Guns.xml
@@ -200,6 +200,7 @@
 						<aimedBurstShotCount>5</aimedBurstShotCount>
 					</FireModes>
 					<weaponTags>
+						<li>Bipod_LMG</li>
 						<li>CE_AI_AR</li>
 						<li>RN_Coalition_MG</li>
 						<li>RNGun_FNMinimi762</li>

--- a/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Sharpshooter.xml
+++ b/Patches/RH2 Faction - The Rangers/Rangers_CE_Patch_Sharpshooter.xml
@@ -48,7 +48,10 @@
 						<aiAimMode>AimedShot</aiAimMode>
 					</FireModes>
 
-					<!-- No additional CE weaponTags needed -->
+					<weaponTags>
+						<li>Bipod_AMR</li>
+					</weaponTags>
+
 					<AllowWithRunAndGun>false</AllowWithRunAndGun>
 				</li>
 

--- a/Patches/RH2 Metal Gear Solid/RH2_MGS_CE_Patch_Apparel_Armor.xml
+++ b/Patches/RH2 Metal Gear Solid/RH2_MGS_CE_Patch_Apparel_Armor.xml
@@ -55,6 +55,61 @@
 					</value>
 				</li>
 
+				<!-- ========== Exo Body ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoSuit_Raiden"]/apparel/bodyPartGroups</xpath>
+					<value>
+						<li>Hands</li>
+						<li>Feet</li>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoSuit_Raiden"]/statBases</xpath>
+					<value>
+						<Bulk>25</Bulk>
+						<WornBulk>20</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoSuit_Raiden"]/equippedStatOffsets</xpath>
+					<value>
+						<CarryWeight>50</CarryWeight>
+						<!-- Essentially cancel out the added bulk of the exosuit -->
+						<CarryBulk>30</CarryBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoSuit_Raiden"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>22</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoSuit_Raiden"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>44</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoSuit_Raiden"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>0.9</ArmorRating_Heat>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoSuit_Raiden" or defName="RHApparel_ExoSuit_GrayFox"]/equippedStatOffsets</xpath>
+					<value>
+						<Suppressability>-3.0</Suppressability>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/RH2 Metal Gear Solid/RH2_MGS_CE_Patch_Apparel_Armor_Headgear.xml
+++ b/Patches/RH2 Metal Gear Solid/RH2_MGS_CE_Patch_Apparel_Armor_Headgear.xml
@@ -58,6 +58,37 @@
 					</value>
 				</li>
 
+				<!-- ========== Exo Suit THI Helmet ========== -->
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoHelmet_Raiden"]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<WornBulk>1.5</WornBulk>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoHelmet_Raiden"]/statBases/ArmorRating_Sharp</xpath>
+					<value>
+						<ArmorRating_Sharp>17</ArmorRating_Sharp>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoHelmet_Raiden"]/statBases/ArmorRating_Blunt</xpath>
+					<value>
+						<ArmorRating_Blunt>34</ArmorRating_Blunt>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RHApparel_ExoHelmet_Raiden"]/statBases/ArmorRating_Heat</xpath>
+					<value>
+						<ArmorRating_Heat>1</ArmorRating_Heat>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/RH2 Metal Gear Solid/RH2_MGS_CE_Patch_MeleeWeapon.xml
+++ b/Patches/RH2 Metal Gear Solid/RH2_MGS_CE_Patch_MeleeWeapon.xml
@@ -67,6 +67,66 @@
 					</value>
 				</li>
 
+				<!-- ========== Longsword / Katana ========== -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[defName="RHMelee_HF_Blade"]/tools</xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>handle</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>7</power>
+								<chanceFactor>0.38</chanceFactor>
+								<cooldownTime>1.57</cooldownTime>
+								<armorPenetrationBlunt>0.500</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>point</label>
+								<capacities>
+									<li>RHMelee_HFBladeStab</li>
+								</capacities>
+								<power>21</power>
+								<cooldownTime>1</cooldownTime>
+								<armorPenetrationBlunt>15</armorPenetrationBlunt>
+								<armorPenetrationSharp>90</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>blade</label>
+								<capacities>
+									<li>RHMelee_HFBladeSlash</li>
+								</capacities>
+								<power>45</power>
+								<cooldownTime>0.5</cooldownTime>
+								<armorPenetrationBlunt>45</armorPenetrationBlunt>
+								<armorPenetrationSharp>80</armorPenetrationSharp>
+								<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHMelee_HF_Blade"]/statBases</xpath>
+					<value>
+						<Bulk>6</Bulk>
+						<MeleeCounterParryBonus>0.83</MeleeCounterParryBonus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RHMelee_HF_Blade"]/equippedStatOffsets</xpath>
+					<value>
+						<MeleeCritChance>4.5</MeleeCritChance>
+						<MeleeParryChance>1.7</MeleeParryChance>
+						<MeleeDodgeChance>0.9</MeleeDodgeChance>
+					</value>
+				</li>
+
 			</operations>
 		</match>
 	</Operation>

--- a/Patches/RH2 Rimmu-Nation² - Clothing/Armors_CE.xml
+++ b/Patches/RH2 Rimmu-Nation² - Clothing/Armors_CE.xml
@@ -87,6 +87,7 @@
 						defName="RNApparel_OpsCoreFAST_Tan" or
 						defName="RNApparel_OpsCoreFASTBUMP_Multicam" or
 						defName="RNApparel_OpsCoreFASTCarbon_Grey" or
+						defName="RNApparel_OpsCoreFAST_SF" or
 						defName="RNApparel_MICH2000_CAG" or
 						defName="RNApparel_MICH2000_AmericanSniper" or
 						defName="RNApparel_Mk6BallisticHelmet_DDPM" or
@@ -233,7 +234,8 @@
 					<xpath>Defs/ThingDef[
 						defName="RNApparel_OpsCoreFAST_Tan" or
 						defName="RNApparel_OpsCoreFASTBUMP_Multicam" or
-						defName="RNApparel_OpsCoreFASTCarbon_Grey"]/statBases </xpath>
+						defName="RNApparel_OpsCoreFASTCarbon_Grey" or
+						defName="RNApparel_OpsCoreFAST_SF"]/statBases </xpath>
 					<value>
 						<Bulk>3.5</Bulk>
 						<WornBulk>1</WornBulk>
@@ -420,6 +422,39 @@
 					</value>
 				</li>
 
+				<!--OpsCoreFAST SF with Night Vision-->
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_OpsCoreFAST_SF"]/statBases </xpath>
+					<value>
+						<NightVisionEfficiency_Apparel>0.7</NightVisionEfficiency_Apparel>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_OpsCoreFAST_SF"]/recipeMaker/researchPrerequisite </xpath>
+					<value>
+         				<researchPrerequisite>Smithing</researchPrerequisite>
+         				<researchPrerequisite>CE_AdvancedNV</researchPrerequisite>
+					</value>
+				</li>
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="RNApparel_OpsCoreFAST_SF"]/costList </xpath>
+					<value>
+						<stuffCategories>
+							<li>Steeled</li>
+						</stuffCategories>
+						<costStuffCount>45</costStuffCount>
+						<costList>
+							<Plasteel>15</Plasteel>
+							<ComponentIndustrial>5</ComponentIndustrial>
+						</costList>
+					</value>
+				</li>
+
 				<!--========================== Body Armors =====================================-->
 				<!--EOD-->
 				<li Class="PatchOperationAdd">
@@ -582,7 +617,8 @@
 						defName="RNApparel_AR500Veritas_Brown" or
 						defName="RNApparel_MBCFantom_Black" or
 						defName="RNApparel_PACALVC_Tan" or
-						defName="RNApparel_BristolBodyArmor_Olive"]/statBases/Mass </xpath>
+						defName="RNApparel_BristolBodyArmor_Olive" or
+						defName="RNApparel_FirstSpearAACV2_Multicam"]/statBases/Mass </xpath>
 					<value>
 						<Mass>11</Mass>
 						<Bulk>6</Bulk>
@@ -604,7 +640,8 @@
 						defName="RNApparel_AR500Veritas_Brown" or
 						defName="RNApparel_MBCFantom_Black" or
 						defName="RNApparel_PACALVC_Tan" or
-						defName="RNApparel_BristolBodyArmor_Olive"]/statBases/MaxHitPoints </xpath>
+						defName="RNApparel_BristolBodyArmor_Olive" or
+						defName="RNApparel_FirstSpearAACV2_Multicam"]/statBases/MaxHitPoints </xpath>
 					<value>
 						<MaxHitPoints>75</MaxHitPoints>
 					</value>
@@ -624,7 +661,8 @@
 						defName="RNApparel_AR500Veritas_Brown" or
 						defName="RNApparel_MBCFantom_Black" or
 						defName="RNApparel_PACALVC_Tan" or
-						defName="RNApparel_BristolBodyArmor_Olive"]/statBases/ArmorRating_Sharp </xpath>
+						defName="RNApparel_BristolBodyArmor_Olive" or
+						defName="RNApparel_FirstSpearAACV2_Multicam"]/statBases/ArmorRating_Sharp </xpath>
 					<value>
 						<ArmorRating_Sharp>14</ArmorRating_Sharp>
 					</value>
@@ -644,7 +682,8 @@
 						defName="RNApparel_AR500Veritas_Brown" or
 						defName="RNApparel_MBCFantom_Black" or
 						defName="RNApparel_PACALVC_Tan" or
-						defName="RNApparel_BristolBodyArmor_Olive"]/statBases/ArmorRating_Blunt </xpath>
+						defName="RNApparel_BristolBodyArmor_Olive" or
+						defName="RNApparel_FirstSpearAACV2_Multicam"]/statBases/ArmorRating_Blunt </xpath>
 					<value>
 						<ArmorRating_Blunt>20</ArmorRating_Blunt>
 					</value>
@@ -664,7 +703,8 @@
 						defName="RNApparel_AR500Veritas_Brown" or
 						defName="RNApparel_MBCFantom_Black" or
 						defName="RNApparel_PACALVC_Tan" or
-						defName="RNApparel_BristolBodyArmor_Olive"]/equippedStatOffsets/MoveSpeed </xpath>
+						defName="RNApparel_BristolBodyArmor_Olive" or
+						defName="RNApparel_FirstSpearAACV2_Multicam"]/equippedStatOffsets/MoveSpeed </xpath>
 				</li>
 
 				<!--16mm (sharp 1.05)-->

--- a/Patches/RH2 Rimmu-Nation² - Clothing/Bandana_Balaclava_Scarf.xml
+++ b/Patches/RH2 Rimmu-Nation² - Clothing/Bandana_Balaclava_Scarf.xml
@@ -70,6 +70,8 @@
 						or defName="RNApparel_Balaclava_AikuerSkull"
 						or defName="RNApparel_Balaclava_Highlander"
 						or defName="RNApparel_Balaclava_CheekiBreeki"
+						or defName="RNApparel_Balaclava_Reaper"
+						or defName="RNApparel_Balaclava_Clown"
 						]/costStuffCount </xpath>
 					<value>
 						<costStuffCount>20</costStuffCount>
@@ -82,6 +84,8 @@
 						or defName="RNApparel_Balaclava_AikuerSkull"
 						or defName="RNApparel_Balaclava_Highlander"
 						or defName="RNApparel_Balaclava_CheekiBreeki"
+						or defName="RNApparel_Balaclava_Reaper"
+						or defName="RNApparel_Balaclava_Clown"
 						]/statBases/StuffEffectMultiplierArmor </xpath>
 					<value>
 						<Bulk>0.5</Bulk>
@@ -95,7 +99,9 @@
 						or defName="RNApparel_Balaclava_511M"
 						or defName="RNApparel_Balaclava_AikuerSkull"
 						or defName="RNApparel_Balaclava_Highlander"
-						or defName="RNApparel_Balaclava_CheekiBreeki"]/apparel/layers </xpath>
+						or defName="RNApparel_Balaclava_CheekiBreeki"
+						or defName="RNApparel_Balaclava_Reaper"
+						or defName="RNApparel_Balaclava_Clown"]/apparel/layers </xpath>
 					<value>
 						<layers>
 							<li>OnHead</li>
@@ -110,6 +116,8 @@
 						or defName="RNApparel_Balaclava_AikuerSkull"
 						or defName="RNApparel_Balaclava_Highlander"
 						or defName="RNApparel_Balaclava_CheekiBreeki"
+						or defName="RNApparel_Balaclava_Reaper"
+						or defName="RNApparel_Balaclava_Clown"
 						]/apparel/bodyPartGroups </xpath>
 					<value>
 						<bodyPartGroups>
@@ -130,7 +138,8 @@
 						or defName="RNApparel_TrenchCoatHood_PUBG"
 						or defName="RNApparel_Beanie_Skullcap"
 						or defName="RNApparel_FedoraHat_Generic"
-						or defName="RNApparel_Beret_RUMilitary"]/apparel/layers </xpath>
+						or defName="RNApparel_Beret_RUMilitary"
+						or defName="RNApparel_GunslingerHat_Generic"]/apparel/layers </xpath>
 					<value>
 						<layers>
 							<li>Overhead</li>

--- a/Patches/RH2 Rimmu-Nation² - Clothing/Jacket_Rimmu.xml
+++ b/Patches/RH2 Rimmu-Nation² - Clothing/Jacket_Rimmu.xml
@@ -15,6 +15,8 @@
 						or defName="RNApparel_VestJacket_Generic"
 						or defName="RNApparel_BikerJacket_Generic"
 						or defName="RNApparel_SuedeJacket_Generic"
+						or defName="RNApparel_CombatJacket_Generic"
+						or defName="RNApparel_GunslingerJacket_Generic"
 						]/costStuffCount </xpath>
 					<value>
 						<costStuffCount>50</costStuffCount>
@@ -29,6 +31,8 @@
 						or defName="RNApparel_VestJacket_Generic"
 						or defName="RNApparel_BikerJacket_Generic"
 						or defName="RNApparel_SuedeJacket_Generic"
+						or defName="RNApparel_CombatJacket_Generic"
+						or defName="RNApparel_GunslingerJacket_Generic"
 						]/statBases/StuffEffectMultiplierArmor </xpath>
 					<value>
 						<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>

--- a/Patches/RH2 Rimmu-Nation² - Clothing/Shirt_Rimmu.xml
+++ b/Patches/RH2 Rimmu-Nation² - Clothing/Shirt_Rimmu.xml
@@ -14,6 +14,7 @@
 						or defName="RNApparel_Shirt_BlackhawkPursuit"
 						or defName="RNApparel_FlightSuit_Brandit"
 						or defName="RNApparel_UBACShirt_DDPM"
+						or defName="RNApparel_UBACShirt_CryeG2Uniform"
 						]/statBases/Flammability </xpath>
 					<value>
 						<Flammability>0.6</Flammability>
@@ -75,6 +76,7 @@
 						or defName="RNApparel_ACU_UCP"
 						or defName="RNApparel_BDU_DMARPAT"
 						or defName="RNApparel_UBACShirt_DDPM"
+						or defName="RNApparel_UBACShirt_CryeG2Uniform"
 						]/statBases/StuffEffectMultiplierArmor </xpath>
 					<value>
 						<StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>

--- a/Patches/RH2 Rimmu-Nation² - Security/Rimmu2_CE_Security_MG.xml
+++ b/Patches/RH2 Rimmu-Nation² - Security/Rimmu2_CE_Security_MG.xml
@@ -99,14 +99,14 @@
 						<recoilPattern>Mounted</recoilPattern>
 					</Properties>
 					<AmmoUser>
-						<magazineSize>100</magazineSize>
+						<magazineSize>200</magazineSize>
 						<reloadTime>7.8</reloadTime>
 						<ammoSet>AmmoSet_50BMG</ammoSet>
 					</AmmoUser>
 					<FireModes>
 						<aiUseBurstMode>FALSE</aiUseBurstMode>
 						<aiAimMode>SuppressFire</aiAimMode>
-						<aimedBurstShotCount>5</aimedBurstShotCount>
+						<aimedBurstShotCount>10</aimedBurstShotCount>
 					</FireModes>
 					<weaponTags>
 						<li>TurretGun</li>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_BoltAction.xml
@@ -518,6 +518,144 @@
 					<AllowWithRunAndGun>false</AllowWithRunAndGun>
 				</li>
 
+				<!-- ========== Kar98k ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_Kar98k</defName>
+					<statBases>
+						<Mass>4.10</Mass>
+						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.24</SightsEfficiency>
+						<ShotSpread>0.05</ShotSpread>
+						<SwayFactor>1.56</SwayFactor>
+						<Bulk>11.10</Bulk>
+						<WorkToMake>15000</WorkToMake>
+					</statBases>
+					<costList>
+						<WoodLog>15</WoodLog>
+						<Steel>50</Steel>
+						<ComponentIndustrial>2</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_792x57mmMauser_FMJ</defaultProjectile>
+						<warmupTime>1.3</warmupTime>
+						<range>86</range>
+						<soundCast>RNShot_BoltActionOldie</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>5</magazineSize>
+						<reloadTime>4.3</reloadTime>
+						<ammoSet>AmmoSet_792x57mmMauser</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
+
+					<AllowWithRunAndGun>false</AllowWithRunAndGun>
+				</li>
+
+				<!-- ========== M700 ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_M700SAICS_Sniper</defName>
+					<statBases>
+						<Mass>7.50</Mass>
+						<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.72</SightsEfficiency>
+						<ShotSpread>0.04</ShotSpread>
+						<SwayFactor>1.40</SwayFactor>
+						<Bulk>12.24</Bulk>
+						<WorkToMake>31500</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>15</Chemfuel>
+						<Steel>65</Steel>
+						<ComponentIndustrial>5</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.9</warmupTime>
+						<range>75</range>
+						<soundCast>RNShot_SRSSD</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>10</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+
+					<AllowWithRunAndGun>false</AllowWithRunAndGun>
+				</li>
+
+				<!-- ========== Mosin Nagant ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_MosinNagant</defName>
+					<statBases>
+						<Mass>4.00</Mass>
+						<RangedWeapon_Cooldown>1.17</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.21</SightsEfficiency>
+						<ShotSpread>0.03</ShotSpread>
+						<SwayFactor>1.67</SwayFactor>
+						<Bulk>12.32</Bulk>
+						<WorkToMake>15500</WorkToMake>
+					</statBases>
+					<costList>
+						<WoodLog>15</WoodLog>
+						<Steel>55</Steel>
+						<ComponentIndustrial>2</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_762x54mmR_FMJ</defaultProjectile>
+						<warmupTime>1.275</warmupTime>
+						<range>75</range>
+						<soundCast>RNShot_BoltActionOldie</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>5</magazineSize>
+						<reloadTime>4.3</reloadTime>
+						<ammoSet>AmmoSet_762x54mmR</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
+
+					<AllowWithRunAndGun>false</AllowWithRunAndGun>
+				</li>
 				<!-- == Shared patches for firearm melee tools == -->
 
 				<li Class="PatchOperationReplace">
@@ -532,7 +670,10 @@
 						defName="RNGun_M24A2_Sniper" or
 						defName="RNGun_M40A5_Sniper" or
 						defName="RNGun_SV98_Sniper" or
-						defName="RNGun_M200Intervention_AMR"
+						defName="RNGun_M200Intervention_AMR" or
+						defName="RNGun_Kar98k" or
+						defName="RNGun_MosinNagant" or
+						defName="RNGun_M700SAICS_Sniper"
 						]/tools </xpath>
 					<value>
 						<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_DMR.xml
@@ -618,6 +618,46 @@
 					<AllowWithRunAndGun>false</AllowWithRunAndGun>
 				</li>
 
+				<!-- ========== Mk 14 EBR ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_Mk14EBRSD_DMR</defName>
+					<statBases>
+						<Mass>6.75</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.60</SightsEfficiency>
+						<ShotSpread>0.08</ShotSpread>
+						<SwayFactor>1.89</SwayFactor>
+						<Bulk>8.89</Bulk>
+						<WorkToMake>33500</WorkToMake>
+					</statBases>
+					<costList>
+						<Steel>70</Steel>
+						<ComponentIndustrial>6</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.6</warmupTime>
+						<range>75</range>
+						<soundCast>RNShot_DMRSDGeneric_II</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>20</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+				</li>
+
 				<!-- == Shared patches for firearm melee tools == -->
 
 				<li Class="PatchOperationReplace">
@@ -634,7 +674,8 @@
 						defName="RNGun_SVU_DMR" or
 						defName="RNGun_Mk14Mod0_DMR" or
 						defName="RNGun_SKSModern_DMR" or
-						defName="RNGun_DesertTechSRS_DMR"
+						defName="RNGun_DesertTechSRS_DMR" or
+						defName="RNGun_Mk14EBRSD_DMR"
 						]/tools </xpath>
 					<value>
 						<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_GrenadeDeletus.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_GrenadeDeletus.xml
@@ -10,7 +10,7 @@
 				<!-- ========== Remove Grenades and their projectiles ========== -->
 
 				<li Class="PatchOperationRemove">
-					<xpath>Defs/ThingDef[defName="RNThrown_M84Stun_Grenade"]</xpath>
+					<xpath>Defs/ThingDef[defName="RNThrown_M84Stun_Grenade" or defName="RNThrown_RGD5HEGrenade"]</xpath>
 				</li>
 
 			</operations>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Pistols.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Pistols.xml
@@ -348,7 +348,7 @@
 					<Properties>
 						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 						<hasStandardCommand>true</hasStandardCommand>
-						<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+						<ammoSet>AmmoSet_9x19mmPara</ammoSet>
 						<warmupTime>0.6</warmupTime>
 						<range>12</range>
 						<soundCast>RNShot1911P</soundCast>
@@ -599,6 +599,234 @@
 						<li>CE_OneHandedWeapon</li>
 					</weaponTags>
 				</li>
+				<!-- ========== FN Five-seven ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_FiveSevenSD_Pistol</defName>
+					<statBases>
+						<Mass>0.7</Mass>
+						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.70</SightsEfficiency>
+						<ShotSpread>0.17</ShotSpread>
+						<SwayFactor>0.90</SwayFactor>
+						<Bulk>2.2</Bulk>
+						<WorkToMake>7500</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>5</Chemfuel>
+						<Steel>20</Steel>
+						<ComponentIndustrial>3</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>12</range>
+						<soundCast>RNShotSupressed_II</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>20</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_FN57x28mm</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== Glock 17 ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_Glock17SD_Pistol</defName>
+					<statBases>
+						<Mass>0.67</Mass>
+						<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.70</SightsEfficiency>
+						<ShotSpread>0.17</ShotSpread>
+						<SwayFactor>0.83</SwayFactor>
+						<Bulk>1.86</Bulk>
+						<WorkToMake>7500</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>5</Chemfuel>
+						<Steel>20</Steel>
+						<ComponentIndustrial>3</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>12</range>
+						<soundCast>RNShotSupressed_II</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>17</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_Pistol</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== M1911 Silverballer ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_M1911Silverballer_Pistol</defName>
+					<statBases>
+						<Mass>1.2</Mass>
+						<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.70</SightsEfficiency>
+						<ShotSpread>0.17</ShotSpread>
+						<SwayFactor>1.11</SwayFactor>
+						<Bulk>2.25</Bulk>
+						<WorkToMake>7000</WorkToMake>
+					</statBases>
+					<costList>
+						<Steel>25</Steel>
+						<ComponentIndustrial>3</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>12</range>
+						<soundCast>RNShotSupressed_III</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>7</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_45ACP</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_Pistol</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== P226-SD ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_P226SD_Pistol</defName>
+					<statBases>
+						<Mass>1.1</Mass>
+						<RangedWeapon_Cooldown>0.40</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.70</SightsEfficiency>
+						<ShotSpread>0.17</ShotSpread>
+						<SwayFactor>0.97</SwayFactor>
+						<Bulk>1.96</Bulk>
+						<WorkToMake>7000</WorkToMake>
+					</statBases>
+					<costList>
+						<Steel>25</Steel>
+						<ComponentIndustrial>3</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_40SW_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>12</range>
+						<soundCast>RNShotSupressed_II</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>12</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_40SW</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_Pistol</li>
+						<li>CE_Sidearm</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== USP45 SD ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_USPS45_Pistol</defName>
+					<statBases>
+						<Mass>1.23</Mass>
+						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+						<SightsEfficiency>0.70</SightsEfficiency>
+						<ShotSpread>0.11</ShotSpread>
+						<SwayFactor>1.71</SwayFactor>
+						<Bulk>3.92</Bulk>
+						<WorkToMake>8000</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>5</Chemfuel>
+						<Steel>25</Steel>
+						<ComponentIndustrial>3</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_45ACP_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>12</range>
+						<soundCast>RNShotSupressed_III</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>12</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_45ACP</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_Pistol</li>
+						<li>CE_OneHandedWeapon</li>
+					</weaponTags>
+				</li>
 
 				<!-- ========== Juan Deag ========== -->
 
@@ -708,7 +936,12 @@
 						defName="RNGun_P320_Pistol" or
 						defName="RNGun_DesertEagle_Pistol" or
 						defName="RNGun_PT92SF_Pistol" or
-						defName="RNGun_USP45_Pistol"
+						defName="RNGun_USP45_Pistol" or
+						defName="RNGun_FiveSevenSD_Pistol" or
+						defName="RNGun_Glock17SD_Pistol" or
+						defName="RNGun_M1911Silverballer_Pistol" or
+						defName="RNGun_P226SD_Pistol" or
+						defName="RNGun_USPS45_Pistol"
 						]/tools </xpath>
 					<value>
 						<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Rifle1_Style.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Rifle1_Style.xml
@@ -164,7 +164,7 @@
 					<statBases>
 						<Mass>3.60</Mass>
 						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
-						<SightsEfficiency>1.50</SightsEfficiency>
+						<SightsEfficiency>2.06</SightsEfficiency>
 						<ShotSpread>0.08</ShotSpread>
 						<SwayFactor>1.23</SwayFactor>
 						<Bulk>9.43</Bulk>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Rifle2_Style.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Rifle2_Style.xml
@@ -202,7 +202,7 @@
 					<statBases>
 						<Mass>2.90</Mass>
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-						<SightsEfficiency>1.00</SightsEfficiency>
+						<SightsEfficiency>2.06</SightsEfficiency>
 						<ShotSpread>0.1</ShotSpread>
 						<SwayFactor>1.13</SwayFactor>
 						<Bulk>7.56</Bulk>
@@ -299,7 +299,7 @@
 					<statBases>
 						<Mass>3.30</Mass>
 						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
-						<SightsEfficiency>2.24</SightsEfficiency>
+						<SightsEfficiency>1.0</SightsEfficiency>
 						<ShotSpread>0.09</ShotSpread>
 						<SwayFactor>1.32</SwayFactor>
 						<Bulk>7.16</Bulk>
@@ -954,7 +954,7 @@
 				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
 					<defName>RNGun_G3A2_Rifle</defName>
 					<statBases>
-						<WorkToMake>67500</WorkToMake>
+						<WorkToMake>29000</WorkToMake>
 						<SightsEfficiency>1</SightsEfficiency>
 						<ShotSpread>0.08</ShotSpread>
 						<SwayFactor>1.46</SwayFactor>
@@ -994,6 +994,242 @@
 					</FireModes>
 				</li>
 
+				<!-- ========== Heckler & Koch HK416 SD DEVGRU ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_M4A1DEVGRU_Rifle</defName>
+					<statBases>
+						<Mass>4.44</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.06</SightsEfficiency>
+						<ShotSpread>0.05</ShotSpread>
+						<SwayFactor>1.62</SwayFactor>
+						<Bulk>10.39</Bulk>
+						<WorkToMake>37500</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>10</Chemfuel>
+						<Steel>55</Steel>
+						<ComponentIndustrial>6</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.27</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.3</warmupTime>
+						<range>62</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+						<soundCast>RNShot_SDAR</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+				</li>
+
+				<!-- ========== AKM ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_AKMSD_Rifle</defName>
+					<statBases>
+						<Mass>3.10</Mass>
+						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.10</SightsEfficiency>
+						<ShotSpread>0.09</ShotSpread>
+						<SwayFactor>1.19</SwayFactor>
+						<Bulk>8.80</Bulk>
+						<WorkToMake>27000</WorkToMake>
+					</statBases>
+					<costList>
+						<WoodLog>10</WoodLog>
+						<Steel>45</Steel>
+						<ComponentIndustrial>5</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.92</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_762x39mmSoviet_FMJ</defaultProjectile>
+						<warmupTime>1.1</warmupTime>
+						<range>44</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+						<soundCast>RNShot_SDAR</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+						<recoilPattern>Regular</recoilPattern>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_Rifle</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== Remington ACR ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_ACRSD_Rifle</defName>
+					<statBases>
+						<Mass>3.30</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.06</SightsEfficiency>
+						<ShotSpread>0.09</ShotSpread>
+						<SwayFactor>1.32</SwayFactor>
+						<Bulk>7.16</Bulk>
+						<WorkToMake>35500</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>10</Chemfuel>
+						<Steel>40</Steel>
+						<ComponentIndustrial>6</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.55</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.3</warmupTime>
+						<range>55</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+						<soundCast>RNShot_SDAR</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+				</li>
+
+				<!-- ========== FN FAL ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_FNFALTatiana_Rifle</defName>
+					<statBases>
+						<Mass>3.30</Mass>
+						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.10</SightsEfficiency>
+						<ShotSpread>0.06</ShotSpread>
+						<SwayFactor>1.52</SwayFactor>
+						<Bulk>10.90</Bulk>
+						<WorkToMake>29000</WorkToMake>
+					</statBases>
+					<costList>
+						<WoodLog>10</WoodLog>
+						<Steel>55</Steel>
+						<ComponentIndustrial>5</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>2.08</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_762x51mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.1</warmupTime>
+						<range>48</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+						<soundCast>RNShot_DMRSDGeneric</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>20</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+				</li>
+
+				<!-- ========== FN SCAR-L ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_SCARLSD_Rifle</defName>
+					<statBases>
+						<Mass>3.29</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>2.06</SightsEfficiency>
+						<ShotSpread>0.1</ShotSpread>
+						<SwayFactor>1.26</SwayFactor>
+						<Bulk>6.35</Bulk>
+						<WorkToMake>35500</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>10</Chemfuel>
+						<Steel>40</Steel>
+						<ComponentIndustrial>6</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.45</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>
+						<warmupTime>1.3</warmupTime>
+						<range>55</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+						<soundCast>RNShot_SDAR</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>TRUE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+				</li>
+
 				<!-- == Shared patches for firearm melee tools == -->
 
 				<li Class="PatchOperationReplace">
@@ -1017,7 +1253,12 @@
 						defName="RNGun_F2000_Rifle" or
 						defName="RNGun_G3A2_Rifle" or
 						defName="RNGun_ACR_Rifle" or
-						defName="RNGun_TAR-21_Rifle"
+						defName="RNGun_TAR-21_Rifle" or
+						defName="RNGun_M4A1DEVGRU_Rifle" or
+						defName="RNGun_AKMSD_Rifle" or
+						defName="RNGun_ACRSD_Rifle" or
+						defName="RNGun_FNFALTatiana_Rifle" or
+						defName="RNGun_SCARLSD_Rifle"
 						]/tools </xpath>
 					<value>
 						<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_SMG.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_SMG.xml
@@ -591,6 +591,153 @@
 					</weaponTags>
 				</li>
 
+				<!-- ========== AK-74U ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_AK7S4U_SMG</defName>
+					<statBases>
+						<Mass>2.85</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.10</SightsEfficiency>
+						<ShotSpread>0.14</ShotSpread>
+						<SwayFactor>1.02</SwayFactor>
+						<Bulk>4.90</Bulk>
+						<WorkToMake>29000</WorkToMake>
+					</statBases>
+					<costList>
+						<Steel>40</Steel>
+						<ComponentIndustrial>5</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.53</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
+						<warmupTime>0.66</warmupTime>
+						<range>40</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>6</ticksBetweenBurstShots>
+						<soundCast>RNShot_SDAR</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_545x39mmSoviet</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_AssaultWeapon</li>
+						<li>CE_SMG</li>
+					</weaponTags>
+				</li>
+
+				<!-- ========== P90-SD ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_P90SD_PDW</defName>
+					<statBases>
+						<Mass>2.60</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.10</SightsEfficiency>
+						<ShotSpread>0.12</ShotSpread>
+						<SwayFactor>0.8</SwayFactor>
+						<Bulk>5.05</Bulk>
+						<WorkToMake>37000</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>10</Chemfuel>
+						<Steel>30</Steel>
+						<ComponentIndustrial>7</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.05</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_FN57x28mm_FMJ</defaultProjectile>
+						<warmupTime>0.5</warmupTime>
+						<range>31</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+						<soundCast>RNShotSMG2SD</soundCast>
+						<soundCastTail>GunTail_Light</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>50</magazineSize>
+						<reloadTime>4.5</reloadTime>
+						<ammoSet>AmmoSet_FN57x28mm</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+				</li>
+
+				<!-- ========== MP5SD ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_MP5SD_SMG</defName>
+					<statBases>
+						<Mass>2.50</Mass>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.10</SightsEfficiency>
+						<ShotSpread>0.13</ShotSpread>
+						<SwayFactor>0.93</SwayFactor>
+						<Bulk>6.80</Bulk>
+						<WorkToMake>27500</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>5</Chemfuel>
+						<Steel>40</Steel>
+						<ComponentIndustrial>5</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<recoilAmount>1.60</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_9x19mmPara_FMJ</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>31</range>
+						<burstShotCount>6</burstShotCount>
+						<ticksBetweenBurstShots>5</ticksBetweenBurstShots>
+						<soundCast>RNShotSMGSD</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>4</reloadTime>
+						<ammoSet>AmmoSet_9x19mmPara</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_AssaultWeapon</li>
+						<li>CE_SMG</li>
+					</weaponTags>
+				</li>
+
+
 				<!-- == Shared patches for firearm melee tools == -->
 
 				<li Class="PatchOperationReplace">
@@ -606,7 +753,10 @@
 						defName="RNGun_UMP45_SMG" or
 						defName="RNGun_PP19_SMG" or
 						defName="RNGun_Uzi_SMG" or
-						defName="RNGun_KrissVector_PDW"
+						defName="RNGun_KrissVector_PDW" or
+						defName="RNGun_AK7S4U_SMG" or
+						defName="RNGun_P90SD_PDW" or
+						defName="RNGun_MP5SD_SMG"
 						]/tools </xpath>
 					<value>
 						<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Shotguns.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Shotguns.xml
@@ -67,7 +67,7 @@
 						<ShotSpread>0.14</ShotSpread>
 						<SwayFactor>1.32</SwayFactor>
 						<Bulk>9.78</Bulk>
-						<WorkToMake>1000</WorkToMake>
+						<WorkToMake>19500</WorkToMake>
 					</statBases>
 					<costList>
 						<Chemfuel>10</Chemfuel>
@@ -613,6 +613,52 @@
 					</weaponTags>
 				</li>
 
+				<!-- ========== M1014 / Benelli M4 Super 90 ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNGun_M1014SD_Shotgun</defName>
+					<statBases>
+						<Mass>3.82</Mass>
+						<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+						<SightsEfficiency>1</SightsEfficiency>
+						<ShotSpread>0.14</ShotSpread>
+						<SwayFactor>1.27</SwayFactor>
+						<Bulk>10.10</Bulk>
+						<WorkToMake>18000</WorkToMake>
+					</statBases>
+					<costList>
+						<Chemfuel>10</Chemfuel>
+						<Steel>55</Steel>
+						<ComponentIndustrial>3</ComponentIndustrial>
+					</costList>
+					<Properties>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12Gauge_Buck</defaultProjectile>
+						<warmupTime>0.6</warmupTime>
+						<range>16</range>
+						<soundCast>RNShotM1014SD</soundCast>
+						<soundCastTail>GunTail_Heavy</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>8</magazineSize>
+						<reloadOneAtATime>true</reloadOneAtATime>
+						<reloadTime>0.8</reloadTime>
+						<ammoSet>AmmoSet_12Gauge</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>Snapshot</aiAimMode>
+					</FireModes>
+
+					<weaponTags>
+						<li>CE_AI_AssaultWeapon</li>
+					</weaponTags>
+				</li>
+
 				<!-- == Shared patches for firearm melee tools == -->
 
 				<!-- shotguns with stocks -->
@@ -630,7 +676,8 @@
 						defName="RNGun_USAS12_Shotgun" or
 						defName="RNGun_M1014_Shotgun" or
 						defName="RNGun_SpartanMarine_Shotgun" or
-						defName="RNGun_PancorJackhammer_Shotgun"
+						defName="RNGun_PancorJackhammer_Shotgun" or
+						defName="RNGun_M1014SD_Shotgun"
 						]/tools </xpath>
 					<value>
 						<tools>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Spacers.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_CE_Spacers.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>[RH2] Rimmu-Nation² - Weapons</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+
+				<!-- ========== Auger Mk II ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNSci_AugerMkII</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.05</SightsEfficiency>
+						<ShotSpread>0.06</ShotSpread>
+						<SwayFactor>1.2</SwayFactor>
+						<Bulk>8.07</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.13</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
+						<warmupTime>1.2</warmupTime>
+						<range>30.9</range>
+						<burstShotCount>3</burstShotCount>
+						<ticksBetweenBurstShots>8</ticksBetweenBurstShots>
+						<soundCast>RNAugerMkIIShot</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+						<recoilPattern>Regular</recoilPattern>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>2.40</reloadTime>
+						<ammoSet>AmmoSet_6x24mmCharged</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+				</li>
+
+				<!-- ========== BM003 Razor ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNSci_BM003Razor</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.05</SightsEfficiency>
+						<ShotSpread>0.06</ShotSpread>
+						<SwayFactor>1.2</SwayFactor>
+						<Bulk>8.07</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.03</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_8x35mmCharged</defaultProjectile>
+						<warmupTime>0.9</warmupTime>
+						<range>35.9</range>
+						<burstShotCount>5</burstShotCount>
+						<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+						<soundCast>RNRazorShot</soundCast>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+						<recoilPattern>Regular</recoilPattern>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>30</magazineSize>
+						<reloadTime>2.40</reloadTime>
+						<ammoSet>AmmoSet_8x35mmCharged</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>3</aimedBurstShotCount>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+				</li>
+
+				<!-- ========== Longbow 1S-1K ========== -->
+
+				<li Class="CombatExtended.PatchOperationMakeGunCECompatible">
+					<defName>RNSci_Longbow1S1K</defName>
+					<statBases>
+						<RangedWeapon_Cooldown>1.36</RangedWeapon_Cooldown>
+						<SightsEfficiency>1.45</SightsEfficiency>
+						<ShotSpread>0.02</ShotSpread>
+						<SwayFactor>1.0</SwayFactor>
+						<Bulk>11.07</Bulk>
+					</statBases>
+					<Properties>
+						<recoilAmount>1.0</recoilAmount>
+						<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+						<hasStandardCommand>true</hasStandardCommand>
+						<defaultProjectile>Bullet_12x64mmCharged</defaultProjectile>
+						<warmupTime>0.9</warmupTime>
+						<range>40.9</range>
+						<burstShotCount>1</burstShotCount>
+						<ticksBetweenBurstShots>22</ticksBetweenBurstShots>
+						<soundCast>RNLongbowShot</soundCast>
+						<soundAiming>RNLongbowCharge</soundAiming>
+						<soundCastTail>GunTail_Medium</soundCastTail>
+						<muzzleFlashScale>9</muzzleFlashScale>
+						<recoilPattern>Regular</recoilPattern>
+					</Properties>
+
+					<AmmoUser>
+						<magazineSize>5</magazineSize>
+						<reloadTime>2.4</reloadTime>
+						<ammoSet>AmmoSet_12x64mmCharged</ammoSet>
+					</AmmoUser>
+
+					<FireModes>
+						<aiUseBurstMode>FALSE</aiUseBurstMode>
+						<aiAimMode>AimedShot</aiAimMode>
+						<aimedBurstShotCount>1</aimedBurstShotCount>
+					</FireModes>
+
+					<!-- No additional CE weaponTags needed -->
+				</li>
+
+				<!-- == Shared patches for firearm melee tools == -->
+
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/ThingDef[
+						defName="RNSci_AugerMkII" or
+						defName="RNSci_BM003Razor" or
+						defName="RNSci_Longbow1S1K"
+						]/tools </xpath>
+					<value>
+						<tools>
+							<li Class="CombatExtended.ToolCE">
+								<label>stock</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<chanceFactor>1.5</chanceFactor>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>barrel</label>
+								<capacities>
+									<li>Blunt</li>
+								</capacities>
+								<power>5</power>
+								<cooldownTime>2.02</cooldownTime>
+								<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+							</li>
+							<li Class="CombatExtended.ToolCE">
+								<label>muzzle</label>
+								<capacities>
+									<li>Poke</li>
+								</capacities>
+								<power>8</power>
+								<cooldownTime>1.55</cooldownTime>
+								<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+								<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+							</li>
+						</tools>
+					</value>
+				</li>
+
+			</operations>
+		</match>
+	</Operation>
+
+</Patch>

--- a/Patches/RH2 Rimmu-Nation² - Weapons/RM2_Swords_CE.xml
+++ b/Patches/RH2 Rimmu-Nation² - Weapons/RM2_Swords_CE.xml
@@ -18,7 +18,7 @@
 
 				<!-- === Katana === -->
 				<li Class="PatchOperationReplace">
-					<xpath>Defs/ThingDef[defName="RNMeleeWeapon_Mizutori_Katana" or defName="RNMeleeWeapon_Fudoshin_Katana" or defName="RNMeleeWeapon_Yanmaodao_Saber"]/tools</xpath>
+					<xpath>Defs/ThingDef[defName="RNMeleeWeapon_Mizutori_Katana" or defName="RNMeleeWeapon_Fudoshin_Katana" or defName="RNMeleeWeapon_Yanmaodao_Saber" or defName = "RNMeleeWeapon_Manganese_Wakizashi"]/tools</xpath>
 					<value>
 						<tools>
 							<li Class="CombatExtended.ToolCE">
@@ -61,7 +61,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNMeleeWeapon_Mizutori_Katana" or defName="RNMeleeWeapon_Fudoshin_Katana" or defName="RNMeleeWeapon_Yanmaodao_Saber"]/statBases</xpath>
+					<xpath>Defs/ThingDef[defName="RNMeleeWeapon_Mizutori_Katana" or defName="RNMeleeWeapon_Fudoshin_Katana" or defName="RNMeleeWeapon_Yanmaodao_Saber" or defName = "RNMeleeWeapon_Manganese_Wakizashi"]/statBases</xpath>
 					<value>
 						<Bulk>7.85</Bulk>
 						<MeleeCounterParryBonus>1.38</MeleeCounterParryBonus>
@@ -69,7 +69,7 @@
 				</li>
 
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[defName="RNMeleeWeapon_Mizutori_Katana" or defName="RNMeleeWeapon_Fudoshin_Katana" or defName="RNMeleeWeapon_Yanmaodao_Saber"]</xpath>
+					<xpath>Defs/ThingDef[defName="RNMeleeWeapon_Mizutori_Katana" or defName="RNMeleeWeapon_Fudoshin_Katana" or defName="RNMeleeWeapon_Yanmaodao_Saber" or defName = "RNMeleeWeapon_Manganese_Wakizashi"]</xpath>
 					<value>
 						<equippedStatOffsets>
 							<MeleeCritChance>0.86</MeleeCritChance>


### PR DESCRIPTION
## Additions

-Adding patches to newly added armor, clothing, and weapons from the RH2 mod series.

## Changes

-Tweaking existing patches to be more accurate (like adding bipod to Hecate II and FN Minimi from Rangers and 141 Task Force, respectively).

-Merging Chicken's patches to CE proper.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (3 hours on 1.4)
